### PR TITLE
Added placeholders for Nirvana reference files

### DIFF
--- a/annotation/b37/nirvana/v24.tar.gz
+++ b/annotation/b37/nirvana/v24.tar.gz
@@ -1,0 +1,2 @@
+Obtained from: /mnt/storage/apps/software/nirvana/2.0.3/Data/v24.tar.gz
+md5sum: 94c97e749764c72afe4c0acb88044b02

--- a/annotation/b37/nirvana/v41_GRCh37.tar.gz
+++ b/annotation/b37/nirvana/v41_GRCh37.tar.gz
@@ -1,0 +1,2 @@
+Obtained from: /mnt/storage/apps/software/nirvana/2.0.3/Data/v41_GRCh37.tar.gz
+md5sum: aeaa083ebcb9686082ae40f2dd5fa603

--- a/annotation/b37/nirvana/v5.tar.gz
+++ b/annotation/b37/nirvana/v5.tar.gz
@@ -1,0 +1,2 @@
+Obtained from: /mnt/storage/apps/software/nirvana/2.0.3/Data/v41_GRCh37.tar.gz
+md5sum: 96b843beaef2f69283009f642e025d82


### PR DESCRIPTION
Actual files are too large for github, therefore placeholders are text files describing for each file:
source: where to obtain the actual file 
md5sum; checksum for actual file (not placeholder file) to enable integrity checks

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_001_reference/10)
<!-- Reviewable:end -->
