### PR TITLE
Nirvana 2010 data

### DIFF
--- a/annotation/b37/nirvana/v26.tar.gz
+++ b/annotation/b37/nirvana/v26.tar.gz
@@ -1,2 +1,2 @@
 Obtained from: https://illumina-annotation.s3.amazonaws.com/Cache/v26.tar.gz
-md5sum: 
+md5sum: e30416d7090d91f63a044e2cc095f8db

--- a/annotation/b37/nirvana/v26.tar.gz
+++ b/annotation/b37/nirvana/v26.tar.gz
@@ -1,0 +1,2 @@
+Obtained from: https://illumina-annotation.s3.amazonaws.com/Cache/v26.tar.gz
+md5sum: 

--- a/annotation/b37/nirvana/v44_GRCh37.tar.gz
+++ b/annotation/b37/nirvana/v44_GRCh37.tar.gz
@@ -1,2 +1,2 @@
 Obtained from: https://illumina-annotation.s3.amazonaws.com/SA/44/v44_GRCh37.tar.gz
-md5sum: 
+md5sum: d6e0feb0b88a56baec878719371fce56

--- a/annotation/b37/nirvana/v44_GRCh37.tar.gz
+++ b/annotation/b37/nirvana/v44_GRCh37.tar.gz
@@ -1,0 +1,2 @@
+Obtained from: https://illumina-annotation.s3.amazonaws.com/SA/44/v44_GRCh37.tar.gz
+md5sum: 


### PR DESCRIPTION
Added Nirvana 2.0.10 annotation data file placeholders. Placeholders contain the original source of the file and the md5sum of the file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_001_reference/14)
<!-- Reviewable:end -->
