### PR TITLE
gemini_multiqc_config_v1.0.6

### DIFF
--- a/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
+++ b/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
@@ -1,0 +1,351 @@
+###################################################
+# Eggd MultiQC Configuration File for Gemini
+###################################################
+
+# This file can be saved either in the MultiQC installation
+# directory, or as ~/.multiqc_config.yaml
+
+# Configuration settings are taken from the following locations, in order:
+# - Hardcoded in MultiQC (multiqc/utils/config.py)
+# - <installation_dir>/multiqc_config.yaml
+# - ~/.multiqc_config.yaml
+# - Command line options
+
+# Note that all of the values below are set to the MultiQC defaults.
+# It's recommended that you delete any that you don't need.
+
+#################################################################
+
+# Title to use for the report.
+title: East GLH MultiQC Report
+subtitle: TruSight One Expanded     # Grey text below title
+# intro_text: null          # Set to False to remove, or your own text
+
+# # Add generic information to the top of reports
+# report_header_info:
+#     - Example Config:: 'This is arbitrary'
+#     - Another field:: 'Loaded from <code>multiqc_config_example.yaml</code>'
+#     - Something different:: 'You can put any key-value pairs here'
+#     - Want to know more?: 'See the <a href="http://multiqc.info/docs" target="_blank">MultiQC docs</a>'
+# # Specify a custom logo to add to reports (uncomment to use)
+# custom_logo: 'link to egglogo.png'         # '/path/to/logo.png'
+# custom_logo_url: 'https://cuhbioinformatics.atlassian.net/servicedesk/customer/portal/3'     # 'https://www.example.com'
+# custom_logo_title: 'Bioinformatics Help Desk'   # 'Our Institute Name'
+
+# Default output filenames
+output_fn_name: multiqc_report.html
+data_dir_name: multiqc_data
+
+# Prepend sample names with their directory. Useful if analysing the
+# sample samples with different parameters.
+prepend_dirs: False
+# Whether to create the parsed data directory in addition to the report
+make_data_dir: True
+
+# Cleaning options for sample names. Typically, sample names are detected
+# from an input filename. If any of these strings are found, they and any
+# text to their right will be discarded.
+# For example - file1.fq.gz_trimmed.bam_deduplicated_fastqc.zip
+# would be cleaned to 'file1'
+# Two options here - fn_clean_exts will replace the defaults,
+# extra_fn_clean_exts will append to the defaults
+extra_fn_clean_exts:
+    - type: remove
+      pattern: '_001'      
+    - type: remove
+      pattern: '.markdup'
+    - type: remove
+      pattern: '_markdup' 
+    - type: remove
+      pattern: '.realigned'
+    - type: remove
+      pattern: '_metrics'
+    - type: remove
+      pattern: '.Duplication_metrics'
+    - type: remove
+      pattern: '.Duplication'
+    - type: remove
+      pattern: '.duplication'
+    - type: remove
+      pattern: '.AlignmentStat'
+    - type: remove
+      pattern: '.GCBias'
+    - type: remove
+      pattern: '.InsertSize'
+    - type: remove
+      pattern: '.MeanQualityByCycle_metrics'
+    - type: remove
+      pattern: '.QualDistribution_metrics'
+    # - .gz
+    # - .fastq
+    # - .fq
+    # - .bam
+    # - .sam
+    # - .sra
+    # - _tophat
+    # - _star_aligned
+    # - _fastqc
+    # - type: replace
+    #   pattern: '.sorted'
+    # - type: regex
+    #   pattern: '^Sample_\d+'
+
+# Ignore these files / directories / paths when searching for logs
+# fn_ignore_files:
+#     - .DS_Store
+# fn_ignore_dirs:
+#     - annoying_dirname
+# fn_ignore_paths:
+#     - '*/path/to/*_files/'
+
+# Ignore files larger than this when searcing for logs (bytes)
+log_filesize_limit: 5000000000
+
+# MultiQC skips a couple of debug messages when searching files as the
+# log can get very verbose otherwise. Re-enable here to help debugging.
+report_readerrors: False
+report_imgskips: False
+
+# Opt-out of remotely checking that you're running the latest version
+no_version_check: False
+
+# Overwrite module order (in report).
+# See multiqc/utils/config_defaults.yaml for the defaults.
+module_order:
+    - 'custom_content'
+    - verifybamid:
+        module_tag:
+            - DNA
+    - picard:
+        module_tag:
+            - DNA
+            - RNA
+    - sentieon:
+        module_tag:
+            - DNA
+    - samtools:
+        module_tag:
+            - DNA
+            - RNA
+    - fastqc:
+        module_tag:
+            - RNA
+            - DNA
+
+# Add code to include data from custom QC reports
+custom_data:
+    vcf_qc_files:
+        file_format: 'tsv'
+        section_name: 'Het-hom analysis'
+        description: 'This plot comes from vcf_qc files'
+        plot_type: 'table'
+        pconfig:
+            id: 'het-hom_table'
+            table_title: 'Het-hom'
+            'col1_header': 'Sample'
+            'col2_header': 'mean het ratio'
+            'col3_header': 'mean homo ratio'
+            'col4_header': 'het:homo ratio'
+            'col5_header': 'X homo:het ratio'
+            'col6_header': 'gender'
+        headers:
+            mean het ratio:
+                format:  '{:,.2f}'
+            mean homo ratio:
+                format:  '{:,.2f}'
+            het:homo ratio:
+                format:  '{:,.2f}'
+            X homo:het ratio:
+                format:  '{:,.2f}'
+            gender:
+                title:  'Inferred sex'
+    custom_coverage:
+        file_format: 'csv'
+        plot_type: 'generalstats'
+        namespace: 'custom_coverage'
+        pconfig:
+            - 'percentage':
+                max: 100
+                min: 0
+                scale: 'RdYlGn'
+                suffix: '%'
+
+# How to plot graphs. Different templates can override these settings, but
+# the default template can use interactive plots (Javascript using HighCharts)
+# or flat plots (images, using MatPlotLib). With interactive plots, the report
+# can prevent automatically rendering all graphs if there are lots of samples
+# to prevent the browser being locked up when the report opens.
+plots_force_flat: False          # Try to use only flat image graphs
+plots_force_interactive: False   # Try to use only interactive javascript graphs
+plots_flat_numseries: 200        # If neither of the above, use flat if > this number of datasets
+num_datasets_plot_limit: 100      # If interactive, don't plot on load if > this number of datasets
+max_table_rows: 500              # Swap tables for a beeswarm plot above this
+
+# Overwrite the defaults of which table columns are visible by default
+table_columns_visible:
+    bcl2fastq:
+        total: False
+        percent_R1_Q30: False
+        percent_R2_Q30: False
+        R1_trimmed_bases: False
+        R2_trimmed_bases: False
+    FastQC: False
+    #     percent_fails: False
+    #     total_sequences: True
+    Peddy:
+        family_id: False
+        ancestry-prediction: False
+        ancestry-prob_het_check: False
+        predicted_sex_sex_check: False
+        predicted_sex_sex_check: False    
+        sex_het_ratio: True
+        sex_error: True
+    verifyBAMID:
+        CHIPMIX: False
+
+table_columns_placement:
+    header_mqc-generalstats-bcl2fastq-yieldQ30: 9600
+    header_mqc-generalstats-bcl2fastq-perfectPercent: 970
+    header_mqc-generalstats-samtools-mapped_passed: 980
+    header_mqc-generalstats-verifybamid-FREEMIX: 990
+    header_mqc-generalstats-picard-PCT_TARGET_BASES_20X: 1000
+    mqc-generalstats-picard-PERCENT_DUPLICATION header: 1010
+    header_mqc-generalstats-sentieon-PCT_PF_READS_ALIGNED: 1020
+    mqc-generalstats-sentieon-summed_median header: 1030
+
+
+# Set picard configs
+picard_config:
+    general_stats_target_coverage: # should be referred to as 'mqc-generalstats-picard-PCT_TARGET_BASES_20X'
+        - 20                           # for conditional table formatting
+
+table_cond_formatting_colours:
+    - blue: '#337ab7'
+    - lbue: '#5bc0de'
+    - pass: '#5cb85c'
+    - warn: '#f0ad4e'
+    - fail: '#d9534f'
+
+# Set conditional formatting rules for general stats FREEMIX
+table_cond_formatting_rules:
+    mqc-generalstats-verifybamid-FREEMIX: #verifyBamId Contaminantion column in General Stats
+        pass:
+            - lt: 2
+        warn:
+            - eq: 2
+            - gt: 2
+        fail:
+            - eq: 5
+            - gt: 5
+    mean_het_ratio: # vcf_qc mean het ratio column
+        pass:
+            - gt: 0
+        fail:
+            - lt: 0.45
+            - gt: 0.50
+    FOLD_80_BASE_PENALTY: # Picard HSMetrics fold 80 base penalty column
+        pass:
+            - lt: 1.80
+        warn:
+            - eq: 1.80
+            - gt: 1.80
+    mqc-generalstats-picard-PCT_TARGET_BASES_20X: # Percentage of target bases at 20x    
+        pass:                                     # number in name depends on what is set above
+            - lt: 101
+        warn:
+            - eq: 98.0
+            - lt: 98.0
+            # - gt: 95.0
+        fail:
+            - eq: 95.0
+            - lt: 95.0
+    METRIC_Recall_indel: # Happy indel Recall outputs
+        pass:
+            - gt: 0.850
+            - eq: 0.850
+        warn:
+            - lt: 0.850
+        fail:
+            - lt: 0.840
+    METRIC_Precision_indel: # Happy indel Precision outputs
+        pass:
+            - gt: 0.620
+            - eq: 0.620
+        warn:
+            - lt: 0.620
+        # fail:
+        #     - lt: 0.600
+    METRIC_Recall_snp:  # Happy snp Recall outputs
+        pass:
+            - gt: 0.995
+            - eq: 0.995
+        warn:
+            - lt: 0.995
+        fail:
+            - lt: 0.990
+    METRIC_Precision_snp:  # Happy snp Precision outputs
+        pass:
+            - gt: 0.995
+            - eq: 0.995
+        warn:
+            - lt: 0.995
+        # fail:
+        #     - lt: 0.990
+    
+    # all_columns:
+    #     pass:
+    #         - s_eq: 'pass'
+    #         - s_eq: 'true'
+    #     warn:
+    #         - s_eq: 'warn'
+    #         - s_eq: 'unknown'
+    #     fail:
+    #         - s_eq: 'fail'
+    #         - s_eq: 'false'
+
+# Overwrite module filename search patterns. See multiqc/utils/search_patterns.yaml
+# for the defaults. Remove a default by setting it to null.
+sp:
+    fastqc/data:
+        fn: '*.stats-fastqc.txt'
+    #picard/alignment_metrics:
+    sentieon/alignment_metrics:
+        fn: '*.AlignmentStat_metrics.txt'
+        shared: true
+    #picard/insertsize:
+    sentieon/insertsize:
+        fn: '*.InsertSize_metrics.txt'
+        shared: true
+    picard/markdups:
+        fn: '*.Duplication_metrics.txt'
+        shared: true
+    #picard/gcbias:
+    sentieon/gcbias:
+        fn: '*.GCBias_metrics.txt'
+        shared: true
+    picard/quality_by_cycle:
+        fn: '*.MeanQualityByCycle_metrics.txt'
+        shared: true
+    picard/quality_score_distribution:
+        fn: '*.QualDistribution_metrics.txt'
+        shared: true
+    verifybamid/selfsm:
+        fn: '*.selfSM'
+    samtools/flagstat:
+        contents: 'in total (QC-passed reads + QC-failed reads)'
+        shared: true
+    vcf_qc_files:
+        fn: '*.vcf.QC'
+    custom_coverage:
+        fn: '*x.csv'
+    happy_snp:
+        fn: '*snp.csv'
+    happy_indel:
+        fn: '*indel.csv'
+
+# Remove plots from HTML report
+remove_sections:
+    # For peddy, keep only the sex-check plot
+    - peddy-pca-plot
+    - peddy-relatedness-plot
+    - peddy-hetcheck-plot

--- a/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
+++ b/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
@@ -161,16 +161,12 @@ custom_data:
                 title:  'Inferred sex'
     custom_coverage:
         file_format: 'csv'
-        section_name: 'Custom coverage'
-        description: 'This plot comes from custom coverage calculations'
-        plot_type: 'table'
+        plot_type: 'generalstats'
         pconfig:
-            id: 'cov_table'
-            table_title: 'Covarage'
-            'col1_header': 'Sample'
-            'col2_header': 'percentage'
-        headers:
-            percentage:
+            - Sample:
+                title: 'Sample Name'
+            - percentage:
+                title: 'Custom coverage'
                 max: 100
                 min: 0
                 scale: 'RdYlGn'

--- a/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
+++ b/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
@@ -161,10 +161,16 @@ custom_data:
                 title:  'Inferred sex'
     custom_coverage:
         file_format: 'csv'
-        plot_type: 'generalstats'
-        namespace: 'custom_coverage'
+        section_name: 'Custom coverage'
+        description: 'This plot comes from custom coverage calculations'
+        plot_type: 'table'
         pconfig:
-            - 'percentage':
+            id: 'cov_table'
+            table_title: 'Covarage'
+            'col1_header': 'Sample'
+            'col2_header': 'percentage'
+        headers:
+            percentage:
                 max: 100
                 min: 0
                 scale: 'RdYlGn'
@@ -203,15 +209,15 @@ table_columns_visible:
     verifyBAMID:
         CHIPMIX: False
 
-table_columns_placement:
-    header_mqc-generalstats-bcl2fastq-yieldQ30: 9600
-    header_mqc-generalstats-bcl2fastq-perfectPercent: 970
-    header_mqc-generalstats-samtools-mapped_passed: 980
-    header_mqc-generalstats-verifybamid-FREEMIX: 990
-    header_mqc-generalstats-picard-PCT_TARGET_BASES_20X: 1000
-    mqc-generalstats-picard-PERCENT_DUPLICATION header: 1010
-    header_mqc-generalstats-sentieon-PCT_PF_READS_ALIGNED: 1020
-    mqc-generalstats-sentieon-summed_median header: 1030
+# table_columns_placement:
+#     header_mqc-generalstats-bcl2fastq-yieldQ30: 960
+#     header_mqc-generalstats-bcl2fastq-perfectPercent: 970
+#     header_mqc-generalstats-samtools-mapped_passed: 980
+#     header_mqc-generalstats-verifybamid-FREEMIX: 990
+#     header_mqc-generalstats-picard-PCT_TARGET_BASES_20X: 1000
+#     mqc-generalstats-picard-PERCENT_DUPLICATION header: 1010
+#     header_mqc-generalstats-sentieon-PCT_PF_READS_ALIGNED: 1020
+#     mqc-generalstats-sentieon-summed_median header: 1030
 
 
 # Set picard configs
@@ -337,7 +343,7 @@ sp:
     vcf_qc_files:
         fn: '*.vcf.QC'
     custom_coverage:
-        fn: '*x.csv'
+        fn: '*x.tsv'
     happy_snp:
         fn: '*snp.csv'
     happy_indel:

--- a/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
+++ b/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
@@ -140,8 +140,8 @@ module_order:
 table_columns_visible:
     bcl2fastq:
         total: False
-        mqc-generalstats-bcl2fastq-percent_R1_Q30: False
-        mqc-generalstats-bcl2fastq-percent_R2_Q30: False
+        percent_R1_Q30: False
+        percent_R2_Q30: False
         R1_trimmed_bases: False
         R2_trimmed_bases: False
     FastQC: False
@@ -158,14 +158,15 @@ table_columns_visible:
 
 # Specify order in which table columns are visible in General Statistics
 table_columns_placement:
-    mqc-generalstats-bcl2fastq-yieldQ30: 960
-    mqc-generalstats-bcl2fastq-perfectPercent: 970
-    mqc-generalstats-samtools-mapped_passed: 980
-    mqc-generalstats-verifybamid-FREEMIX: 990
-    mqc-generalstats-picard-PCT_TARGET_BASES_20X: 1000
-    mqc-generalstats-picard-PERCENT_DUPLICATION header: 1010
-    mqc-generalstats-sentieon-PCT_PF_READS_ALIGNED: 1020
-    mqc-generalstats-sentieon-summed_median header: 1030
+    general_stats_table:
+        yieldQ30: 960
+        perfectPercent: 970
+        mapped_passed: 980
+        FREEMIX: 990
+        PCT_TARGET_BASES_20X: 1000
+        percent_duplicates: 1010
+        PCT_PF_READS_ALIGNED: 1020
+        summed_median: 1030
 
 # Set picard configs: TARGET BASES COVERAGE
 picard_config:

--- a/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
+++ b/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
@@ -343,7 +343,7 @@ sp:
     vcf_qc_files:
         fn: '*.vcf.QC'
     custom_coverage:
-        fn: '*x.tsv'
+        fn: '*x.csv'
     happy_snp:
         fn: '*snp.csv'
     happy_indel:

--- a/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
+++ b/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
@@ -113,9 +113,6 @@ module_order:
     - happy:
         module_tag:
             - DNA
-    - bcl2fastq:
-        module_tag:
-            - DNA
     - 'custom_content'
     - verifybamid:
         module_tag:
@@ -135,6 +132,9 @@ module_order:
         module_tag:
             - RNA
             - DNA
+    - bcl2fastq:
+        module_tag:
+            - DNA
 
 # Overwrite the defaults of which table columns are visible by default
 table_columns_visible:
@@ -145,6 +145,8 @@ table_columns_visible:
         R1_trimmed_bases: False
         R2_trimmed_bases: False
     FastQC: False
+    Picard:
+        FOLD_ENRICHMENT: False
     Peddy:
         family_id: False
         ancestry-prediction: False

--- a/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
+++ b/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
@@ -100,18 +100,33 @@ extra_fn_clean_exts:
 
 # Ignore files larger than this when searcing for logs (bytes)
 log_filesize_limit: 5000000000
-
 # MultiQC skips a couple of debug messages when searching files as the
 # log can get very verbose otherwise. Re-enable here to help debugging.
 report_readerrors: False
 report_imgskips: False
-
 # Opt-out of remotely checking that you're running the latest version
 no_version_check: False
 
-# Overwrite module order (in report).
+# How to plot graphs. Different templates can override these settings, but
+# the default template can use interactive plots (Javascript using HighCharts)
+# or flat plots (images, using MatPlotLib). With interactive plots, the report
+# can prevent automatically rendering all graphs if there are lots of samples
+# to prevent the browser being locked up when the report opens.
+plots_force_flat: False          # Try to use only flat image graphs
+plots_force_interactive: False   # Try to use only interactive javascript graphs
+plots_flat_numseries: 200        # If neither of the above, use flat if > this number of datasets
+num_datasets_plot_limit: 100      # If interactive, don't plot on load if > this number of datasets
+max_table_rows: 500              # Swap tables for a beeswarm plot above this
+
+# Overwrite module order displayed in report.
 # See multiqc/utils/config_defaults.yaml for the defaults.
 module_order:
+    - happy:
+        module_tag:
+            - DNA
+    - bcl2fastq:
+        module_tag:
+            - DNA
     - 'custom_content'
     - verifybamid:
         module_tag:
@@ -132,68 +147,15 @@ module_order:
             - RNA
             - DNA
 
-# Add code to include data from custom QC reports
-custom_data:
-    vcf_qc_files:
-        file_format: 'tsv'
-        section_name: 'Het-hom analysis'
-        description: 'This plot comes from vcf_qc files'
-        plot_type: 'table'
-        pconfig:
-            id: 'het-hom_table'
-            table_title: 'Het-hom'
-            'col1_header': 'Sample'
-            'col2_header': 'mean het ratio'
-            'col3_header': 'mean homo ratio'
-            'col4_header': 'het:homo ratio'
-            'col5_header': 'X homo:het ratio'
-            'col6_header': 'gender'
-        headers:
-            mean het ratio:
-                format:  '{:,.2f}'
-            mean homo ratio:
-                format:  '{:,.2f}'
-            het:homo ratio:
-                format:  '{:,.2f}'
-            X homo:het ratio:
-                format:  '{:,.2f}'
-            gender:
-                title:  'Inferred sex'
-    custom_coverage:
-        file_format: 'csv'
-        plot_type: 'generalstats'
-        pconfig:
-            - Sample:
-                title: 'Sample Name'
-            - percentage:
-                title: 'Custom coverage'
-                max: 100
-                min: 0
-                scale: 'RdYlGn'
-                suffix: '%'
-
-# How to plot graphs. Different templates can override these settings, but
-# the default template can use interactive plots (Javascript using HighCharts)
-# or flat plots (images, using MatPlotLib). With interactive plots, the report
-# can prevent automatically rendering all graphs if there are lots of samples
-# to prevent the browser being locked up when the report opens.
-plots_force_flat: False          # Try to use only flat image graphs
-plots_force_interactive: False   # Try to use only interactive javascript graphs
-plots_flat_numseries: 200        # If neither of the above, use flat if > this number of datasets
-num_datasets_plot_limit: 100      # If interactive, don't plot on load if > this number of datasets
-max_table_rows: 500              # Swap tables for a beeswarm plot above this
-
 # Overwrite the defaults of which table columns are visible by default
 table_columns_visible:
     bcl2fastq:
         total: False
-        percent_R1_Q30: False
-        percent_R2_Q30: False
+        mqc-generalstats-bcl2fastq-percent_R1_Q30: False
+        mqc-generalstats-bcl2fastq-percent_R2_Q30: False
         R1_trimmed_bases: False
         R2_trimmed_bases: False
     FastQC: False
-    #     percent_fails: False
-    #     total_sequences: True
     Peddy:
         family_id: False
         ancestry-prediction: False
@@ -205,16 +167,15 @@ table_columns_visible:
     verifyBAMID:
         CHIPMIX: False
 
-# table_columns_placement:
-#     header_mqc-generalstats-bcl2fastq-yieldQ30: 960
-#     header_mqc-generalstats-bcl2fastq-perfectPercent: 970
-#     header_mqc-generalstats-samtools-mapped_passed: 980
-#     header_mqc-generalstats-verifybamid-FREEMIX: 990
-#     header_mqc-generalstats-picard-PCT_TARGET_BASES_20X: 1000
-#     mqc-generalstats-picard-PERCENT_DUPLICATION header: 1010
-#     header_mqc-generalstats-sentieon-PCT_PF_READS_ALIGNED: 1020
-#     mqc-generalstats-sentieon-summed_median header: 1030
-
+table_columns_placement:
+    mqc-generalstats-bcl2fastq-yieldQ30: 960
+    mqc-generalstats-bcl2fastq-perfectPercent: 970
+    mqc-generalstats-samtools-mapped_passed: 980
+    mqc-generalstats-verifybamid-FREEMIX: 990
+    mqc-generalstats-picard-PCT_TARGET_BASES_20X: 1000
+    mqc-generalstats-picard-PERCENT_DUPLICATION header: 1010
+    mqc-generalstats-sentieon-PCT_PF_READS_ALIGNED: 1020
+    mqc-generalstats-sentieon-summed_median header: 1030
 
 # Set picard configs
 picard_config:
@@ -230,6 +191,15 @@ table_cond_formatting_colours:
 
 # Set conditional formatting rules for general stats FREEMIX
 table_cond_formatting_rules:
+    mqc-generalstats-picard-PCT_TARGET_BASES_20X: # Percentage of target bases at 20x    
+        pass:                                     # number in name depends on what is set above
+            - lt: 101
+        warn:
+            - eq: 98.0
+            - lt: 98.0
+        fail:
+            - eq: 95.0
+            - lt: 95.0
     mqc-generalstats-verifybamid-FREEMIX: #verifyBamId Contaminantion column in General Stats
         pass:
             - lt: 2
@@ -251,16 +221,7 @@ table_cond_formatting_rules:
         warn:
             - eq: 1.80
             - gt: 1.80
-    mqc-generalstats-picard-PCT_TARGET_BASES_20X: # Percentage of target bases at 20x    
-        pass:                                     # number in name depends on what is set above
-            - lt: 101
-        warn:
-            - eq: 98.0
-            - lt: 98.0
-            # - gt: 95.0
-        fail:
-            - eq: 95.0
-            - lt: 95.0
+
     METRIC_Recall_indel: # Happy indel Recall outputs
         pass:
             - gt: 0.850
@@ -304,6 +265,45 @@ table_cond_formatting_rules:
     #     fail:
     #         - s_eq: 'fail'
     #         - s_eq: 'false'
+
+# Add code to include data from custom QC data files
+custom_data:
+    vcf_qc_files:
+        file_format: 'tsv'
+        section_name: 'Het-hom analysis'
+        description: 'This plot comes from vcf_qc files'
+        plot_type: 'table'
+        pconfig:
+            id: 'het-hom_table'
+            table_title: 'Het-hom'
+            'col1_header': 'Sample'
+            'col2_header': 'mean het ratio'
+            'col3_header': 'mean homo ratio'
+            'col4_header': 'het:homo ratio'
+            'col5_header': 'X homo:het ratio'
+            'col6_header': 'gender'
+        headers:
+            mean het ratio:
+                format:  '{:,.2f}'
+            mean homo ratio:
+                format:  '{:,.2f}'
+            het:homo ratio:
+                format:  '{:,.2f}'
+            X homo:het ratio:
+                format:  '{:,.2f}'
+            gender:
+                title:  'Inferred sex'
+    custom_coverage:
+        file_format: 'csv'
+        plot_type: 'generalstats'
+        pconfig:
+            - percentage: # same as in the csv column name
+                description: 'Target bases coverage at custom depth'
+                title: 'Custom coverage'
+                max: 100
+                min: 0
+                scale: 'RdYlGn'
+                suffix: '%'
 
 # Overwrite module filename search patterns. See multiqc/utils/search_patterns.yaml
 # for the defaults. Remove a default by setting it to null.

--- a/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
+++ b/dynamic_files/multiqc_config/gemini_multiqc_config_v1.0.6.yaml
@@ -81,22 +81,11 @@ extra_fn_clean_exts:
     # - .fq
     # - .bam
     # - .sam
-    # - .sra
-    # - _tophat
-    # - _star_aligned
     # - _fastqc
     # - type: replace
     #   pattern: '.sorted'
     # - type: regex
     #   pattern: '^Sample_\d+'
-
-# Ignore these files / directories / paths when searching for logs
-# fn_ignore_files:
-#     - .DS_Store
-# fn_ignore_dirs:
-#     - annoying_dirname
-# fn_ignore_paths:
-#     - '*/path/to/*_files/'
 
 # Ignore files larger than this when searcing for logs (bytes)
 log_filesize_limit: 5000000000
@@ -167,6 +156,7 @@ table_columns_visible:
     verifyBAMID:
         CHIPMIX: False
 
+# Specify order in which table columns are visible in General Statistics
 table_columns_placement:
     mqc-generalstats-bcl2fastq-yieldQ30: 960
     mqc-generalstats-bcl2fastq-perfectPercent: 970
@@ -177,7 +167,7 @@ table_columns_placement:
     mqc-generalstats-sentieon-PCT_PF_READS_ALIGNED: 1020
     mqc-generalstats-sentieon-summed_median header: 1030
 
-# Set picard configs
+# Set picard configs: TARGET BASES COVERAGE
 picard_config:
     general_stats_target_coverage: # should be referred to as 'mqc-generalstats-picard-PCT_TARGET_BASES_20X'
         - 20                           # for conditional table formatting
@@ -189,7 +179,7 @@ table_cond_formatting_colours:
     - warn: '#f0ad4e'
     - fail: '#d9534f'
 
-# Set conditional formatting rules for general stats FREEMIX
+# Set conditional formatting rules for general stats
 table_cond_formatting_rules:
     mqc-generalstats-picard-PCT_TARGET_BASES_20X: # Percentage of target bases at 20x    
         pass:                                     # number in name depends on what is set above
@@ -199,8 +189,8 @@ table_cond_formatting_rules:
             - lt: 98.0
         fail:
             - eq: 95.0
-            - lt: 95.0
-    mqc-generalstats-verifybamid-FREEMIX: #verifyBamId Contaminantion column in General Stats
+            - lt: 95.0      
+    mqc-generalstats-verifybamid-FREEMIX: #verifyBamId Contaminntion column in General Stats
         pass:
             - lt: 2
         warn:
@@ -209,6 +199,7 @@ table_cond_formatting_rules:
         fail:
             - eq: 5
             - gt: 5
+# Set conditional formatting rules for other modules
     mean_het_ratio: # vcf_qc mean het ratio column
         pass:
             - gt: 0
@@ -221,7 +212,15 @@ table_cond_formatting_rules:
         warn:
             - eq: 1.80
             - gt: 1.80
-
+    FREEMIX: #verifyBamId Contamination column in verifybamid
+        pass:
+            - lt: 2
+        warn:
+            - eq: 2
+            - gt: 2
+        fail:
+            - eq: 5
+            - gt: 5
     METRIC_Recall_indel: # Happy indel Recall outputs
         pass:
             - gt: 0.850
@@ -293,17 +292,6 @@ custom_data:
                 format:  '{:,.2f}'
             gender:
                 title:  'Inferred sex'
-    custom_coverage:
-        file_format: 'csv'
-        plot_type: 'generalstats'
-        pconfig:
-            - percentage: # same as in the csv column name
-                description: 'Target bases coverage at custom depth'
-                title: 'Custom coverage'
-                max: 100
-                min: 0
-                scale: 'RdYlGn'
-                suffix: '%'
 
 # Overwrite module filename search patterns. See multiqc/utils/search_patterns.yaml
 # for the defaults. Remove a default by setting it to null.
@@ -338,8 +326,6 @@ sp:
         shared: true
     vcf_qc_files:
         fn: '*.vcf.QC'
-    custom_coverage:
-        fn: '*x.csv'
     happy_snp:
         fn: '*snp.csv'
     happy_indel:


### PR DESCRIPTION
new:
- add assay-specific subtitle to be shown on report (_TruSight One Expanded_)
- include bcl2fastq module

changed:
- specify order and visibility of columns in General Stats
- specify module order (happy, vcf_qc, verifybamid, picard, sentieon, samtools, fastqc, bcl2fastq)
- correct conditional formatting rules

Based on requests in [Helpdesk](https://cuhbioinformatics.atlassian.net/jira/servicedesk/projects/EBH/queues/custom/17/EBH-92)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_001_reference/50)
<!-- Reviewable:end -->
