### PR TITLE
Myeloid config v1.0.1

### DIFF
--- a/dynamic_files/multiqc_config/myeloid_multiqc_config_v1.0.1.yaml
+++ b/dynamic_files/multiqc_config/myeloid_multiqc_config_v1.0.1.yaml
@@ -152,8 +152,10 @@ table_columns_visible:
 table_columns_placement:
     general_stats_table:
         mapped_passed: 950         # M Reads Mapped
-        FREEMIX: 970               # contamination
-        250x: 990
+        FREEMIX: 960               # contamination
+        250x: 970
+        summed_median: 980
+        PCT_AMPLIFIED_BASES: 990
 
 # Set picard configs
 picard_config:


### PR DESCRIPTION
### Updated myeloid multiqc config file ###

* Remove the Target Bases 100X (incorrect)
* Remove % coverage at 500X (keep only 250X)
* Add thresholds to insert size (warning < 150bp)
* Add thresholds to % Amplified bases (warning < 50%)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_001_reference/97)
<!-- Reviewable:end -->
