### PR TITLE
SNP config v1.0.0

### DIFF
--- a/dynamic_files/multiqc_config/SNP_gen_config_v1.0.0.yaml
+++ b/dynamic_files/multiqc_config/SNP_gen_config_v1.0.0.yaml
@@ -1,0 +1,282 @@
+#################################################################
+# Eggd MultiQC Configuration File for SNP genotyping
+#################################################################
+
+# This file can be saved either in the MultiQC installation
+# directory, or as ~/.multiqc_config.yaml
+
+# Configuration settings are taken from the following locations, in order:
+# - Hardcoded in MultiQC (multiqc/utils/config.py)
+# - <installation_dir>/multiqc_config.yaml
+# - ~/.multiqc_config.yaml
+# - Command line options
+
+# Note that all of the values below are set to the MultiQC defaults.
+# It's recommended that you delete any that you don't need.
+
+#################################################################
+
+# Title to use for the report.
+title: East GLH MultiQC Report
+subtitle: SNP genotyping            # Grey text below title
+# intro_text: null          # Set to False to remove, or your own text
+
+# # Add generic information to the top of reports
+# report_header_info:
+#     - Example Config:: 'This is arbitrary'
+#     - Another field:: 'Loaded from <code>multiqc_config_example.yaml</code>'
+#     - Something different:: 'You can put any key-value pairs here'
+#     - Want to know more?: 'See the <a href="http://multiqc.info/docs" target="_blank">MultiQC docs</a>'
+# # Specify a custom logo to add to reports (uncomment to use)
+# custom_logo: 'link to egglogo.png'         # '/path/to/logo.png'
+# custom_logo_url: 'https://cuhbioinformatics.atlassian.net/servicedesk/customer/portal/3'     # 'https://www.example.com'
+# custom_logo_title: 'Bioinformatics Help Desk'   # 'Our Institute Name'
+
+# Default output filenames
+output_fn_name: multiqc_report.html
+data_dir_name: multiqc_data
+
+# Prepend sample names with their directory. Useful if analysing the
+# sample samples with different parameters.
+prepend_dirs: False
+# Whether to create the parsed data directory in addition to the report
+make_data_dir: True
+
+# Cleaning options for sample names. Typically, sample names are detected
+# from an input filename. If any of these strings are found, they and any
+# text to their right will be discarded.
+# For example - file1.fq.gz_trimmed.bam_deduplicated_fastqc.zip
+# would be cleaned to 'file1'
+# Two options here - fn_clean_exts will replace the defaults,
+# extra_fn_clean_exts will append to the defaults
+extra_fn_clean_exts:
+    - type: remove
+      pattern: '_001'      
+    - type: remove
+      pattern: '.markdup'
+    - type: remove
+      pattern: '_markdup' 
+    - type: remove
+      pattern: '.realigned'
+    - type: remove
+      pattern: '_metrics'
+    - type: remove
+      pattern: '.Duplication_metrics'
+    - type: remove
+      pattern: '.Duplication'
+    - type: remove
+      pattern: '.duplication'
+    - type: remove
+      pattern: '.AlignmentStat'
+    - type: remove
+      pattern: '.GCBias'
+    - type: remove
+      pattern: '.InsertSize'
+    - type: remove
+      pattern: '.MeanQualityByCycle_metrics'
+    - type: remove
+      pattern: '.QualDistribution_metrics'
+    # - .gz
+    # - .fastq
+    # - .fq
+    # - .bam
+    # - .sam
+    # - .sra
+    # - _tophat
+    # - _star_aligned
+    # - _fastqc
+    # - type: replace
+    #   pattern: '.sorted'
+    # - type: regex
+    #   pattern: '^Sample_\d+'
+
+# Ignore these files / directories / paths when searching for logs
+# fn_ignore_files:
+#     - .DS_Store
+# fn_ignore_dirs:
+#     - annoying_dirname
+# fn_ignore_paths:
+#     - '*/path/to/*_files/'
+
+# Ignore files larger than this when searcing for logs (bytes)
+log_filesize_limit: 5000000000
+
+# MultiQC skips a couple of debug messages when searching files as the
+# log can get very verbose otherwise. Re-enable here to help debugging.
+report_readerrors: False
+report_imgskips: False
+
+# Opt-out of remotely checking that you're running the latest version
+no_version_check: False
+
+# Overwrite module order (in report).
+# See multiqc/utils/config_defaults.yaml for the defaults.
+module_order:
+    - 'custom_content'
+    - picard:
+        module_tag:
+            - DNA
+            - RNA
+    - sentieon:
+        module_tag:
+            - DNA
+    - samtools:
+        module_tag:
+            - DNA
+            - RNA
+    - fastqc:
+        module_tag:
+            - RNA
+            - DNA
+
+# Add code to include data from custom QC reports
+custom_data:
+    vcf_qc_files:
+        file_format: 'tsv'
+        section_name: 'Het-hom analysis'
+        description: 'This plot comes from vcf_qc files'
+        plot_type: 'table'
+        pconfig:
+            id: 'het-hom_table'
+            table_title: 'Het-hom'
+            'col1_header': 'Sample'
+            'col2_header': 'mean het ratio'
+            'col3_header': 'mean homo ratio'
+            'col4_header': 'het:homo ratio'
+            'col5_header': 'X homo:het ratio'
+            'col6_header': 'gender'
+        headers:
+            mean het ratio:
+                format:  '{:,.2f}'
+            mean homo ratio:
+                format:  '{:,.2f}'
+            het:homo ratio:
+                format:  '{:,.2f}'
+            X homo:het ratio:
+                format:  '{:,.2f}'
+            gender:
+                title:  'Inferred sex'
+
+# How to plot graphs. Different templates can override these settings, but
+# the default template can use interactive plots (Javascript using HighCharts)
+# or flat plots (images, using MatPlotLib). With interactive plots, the report
+# can prevent automatically rendering all graphs if there are lots of samples
+# to prevent the browser being locked up when the report opens.
+plots_force_flat: False          # Try to use only flat image graphs
+plots_force_interactive: False   # Try to use only interactive javascript graphs
+plots_flat_numseries: 200        # If neither of the above, use flat if > this number of datasets
+num_datasets_plot_limit: 100      # If interactive, don't plot on load if > this number of datasets
+max_table_rows: 500              # Swap tables for a beeswarm plot above this
+
+# Overwrite the defaults of which table columns are visible by default
+table_columns_visible:
+    bcl2fastq:
+        total: False
+    FastQC: False
+    #     percent_fails: False
+    #     total_sequences: True
+    Peddy:
+        family_id: False
+        ancestry-prediction: False
+        ancestry-prob_het_check: False
+        predicted_sex_sex_check: False
+        predicted_sex_sex_check: False    
+        sex_het_ratio: True
+        sex_error: True
+    verifyBAMID: False
+    Picard:
+        MEDIAN_TARGET_COVERAGE: False
+    #    CHIPMIX: False
+
+
+# Set picard configs
+picard_config:
+    general_stats_target_coverage: # should be referred to as 'mqc-generalstats-picard-PCT_TARGET_BASES_20X'
+        - 100                       # for conditional table formatting
+
+table_cond_formatting_colours:
+    - blue: '#337ab7'
+    - lbue: '#5bc0de'
+    - pass: '#5cb85c'
+    - warn: '#f0ad4e'
+    - fail: '#d9534f'
+
+# Set conditional formatting rules for general stats FREEMIX
+table_cond_formatting_rules:
+    mean_het_ratio: # vcf_qc mean het ratio column
+        pass:
+            - lt: 0.51
+            - eq: 0.51
+        warn:
+            - eq: 0.52
+            - gt: 0.52
+        fail:
+            - eq: 0.55
+            - gt: 0.55 
+    mqc-generalstats-picard-PCT_TARGET_BASES_100X: # Percentage of target bases at 100x    
+        pass:                                     # number in name depends on what is set above
+            - gt: 9800
+        warn:
+            - eq: 9800
+            - lt: 9800
+        fail:
+            - eq: 9500
+            - lt: 9500
+    FOLD_80_BASE_PENALTY: # Picard HSMetrics fold 80 base penalty column
+        pass:
+            - eq: 1.80
+            - lt: 1.80
+        warn:
+            - gt: 1.80
+
+# Overwrite module filename search patterns. See multiqc/utils/search_patterns.yaml
+# for the defaults. Remove a default by setting it to null.
+sp:
+    happy_snp:
+        fn: '*snp.csv'
+    happy_indel:
+        fn: '*indel.csv'
+    #picard/alignment_metrics:
+    sentieon/alignment_metrics:
+        fn: '*.AlignmentStat_metrics.txt'
+        shared: true
+    #picard/insertsize:
+    sentieon/insertsize:
+        fn: '*.InsertSize_metrics.txt'
+        shared: true
+    picard/markdups:
+        fn: '*.Duplication_metrics.txt'
+        shared: true
+    #picard/gcbias:
+    sentieon/gcbias:
+        fn: '*.GCBias_metrics.txt'
+        shared: true
+    picard/quality_by_cycle:
+        fn: '*.MeanQualityByCycle_metrics.txt'
+        shared: true
+    picard/quality_score_distribution:
+        fn: '*.QualDistribution_metrics.txt'
+        shared: true
+    picard/pcr_metrics:
+        contents: 'TargetedPcrMetrics' #or fn: '*TargetedPcrMetrics.txt'
+        shared: true
+    samtools/flagstat:
+        contents: 'in total (QC-passed reads + QC-failed reads)'
+        shared: true
+    fastqc/data:
+        fn: '*.stats-fastqc.txt'
+
+    vcf_qc_files:
+        fn: '*.vcf.QC'
+
+
+# Remove plots from HTML report
+remove_sections:
+    # For peddy, keep only the sex-check plot
+    - peddy-pca-plot
+    - peddy-relatedness-plot
+    - peddy-hetcheck-plot
+    # Hide the following Picard tables and FastQC plots
+    - fastqc_sequence_duplication_levels
+    - fastqc_overrepresented_sequences
+    - verifybamid


### PR DESCRIPTION
### SNP  genotyping config file for MultiQC ###

#### thresholds: ####

##### 1. Het-hom: #####
* PASS: lower and equal to 0.51
* warning:  equal to 0.52-0.54
* fail: equal and greater than 0.55

##### 2. coverage 100X #####
* PASS: greater than 98%
* warning: equal and lower than 98%
* fail: equal and lower than 95%

##### 3. Fold 80 base penalty #####
* pass: equal and  lower than 1.80
* warning: greater than 1.80

#### Other formatting: ####

* Hide median target coverage from General statistics as it was incorrect
* Show HSmetrics table

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_001_reference/108)
<!-- Reviewable:end -->
