### PR TITLE
Reference genome files for GRCh38 (masked with decoys)

### DIFF
--- a/genomes/b38/GRCh38.no_alt_analysis_set_maskedGRC_exclusions_v2_decoys_nochr.bwa-index.tar.gz
+++ b/genomes/b38/GRCh38.no_alt_analysis_set_maskedGRC_exclusions_v2_decoys_nochr.bwa-index.tar.gz
@@ -1,0 +1,3 @@
+A tarball containing the GRCh38 masked, decoy BWA reference genome index file  is used by sentieon-tnseq app.
+This file is copied into 001 (\resources\genomes\b38\)
+and can be found at project-G6jGkX84kj49v7gk4J16V078:file-GBQv7Z04G5G95z9V97kX03Jj

--- a/genomes/b38/GRCh38.no_alt_analysis_set_maskedGRC_exclusions_v2_decoys_nochr.fa.gz
+++ b/genomes/b38/GRCh38.no_alt_analysis_set_maskedGRC_exclusions_v2_decoys_nochr.fa.gz
@@ -1,0 +1,4 @@
+
+The GRCh38 reference genome file version GRCh38.no_alt_analysis_set_maskedGRC_exclusions_v2_decoys_nochr.fa.gz is used by the sentieon-tnseq, pindel and cgppindel apps.
+This file is copied into 001 (\resources\genomes\b38\)
+and can be found at project-G9FKYPQ4kBX36YFX155g2v39:file-G9z3yG84kj4JPPYx6xQ85kyf

--- a/genomes/b38/GRCh38.no_alt_analysis_set_maskedGRC_exclusions_v2_decoys_nochr.fasta-index.tar.gz
+++ b/genomes/b38/GRCh38.no_alt_analysis_set_maskedGRC_exclusions_v2_decoys_nochr.fasta-index.tar.gz
@@ -1,0 +1,3 @@
+A tarball contaning the GRCh38 masked decoys reference FASTA index file GRCh38.no_alt_analysis_set_maskedGRC_exclusions_v2_decoys_nochr.fasta-index.tar.gz is used by eggd_picard_qc app.
+This file is copied into 001 (\resources\genomes\b38\)
+and can be found at project-G6jGkX84kj49v7gk4J16V078:file-GBV0Qyj4kj40X34V5ypZG5X8


### PR DESCRIPTION
Added :
- BWA reference genome index
- FASTA index archive
- FASTA file
for GRCh38 reference (GRCh38.no_alt_analysis_set_maskedGRC_exclusions_v2_decoys_nochr)