### PR TITLE
added omni25 genotype sites vcf for b38

### DIFF
--- a/assets/verifyBamID/Omni25_genotypes_1525_samples_v2.b38.PASS.ALL.sites_no_chr.vcf.gz
+++ b/assets/verifyBamID/Omni25_genotypes_1525_samples_v2.b38.PASS.ALL.sites_no_chr.vcf.gz
@@ -1,3 +1,3 @@
 A gzipped VCF containing the SNPs used to calculate contamination for for build GRCh38 and is used by the verifybamid app.
 This file is copied into 001 (001_Reference/app_assets/verifyBamID)
-and can be found at project-G9FKYPQ4kBX36YFX155g2v39:file-G7YKFZj4kj47GxgQ2bKGYV1g
+and can be found with file-G7YKFZj4kj47GxgQ2bKGYV1g

--- a/assets/verifyBamID/Omni25_genotypes_1525_samples_v2.b38.PASS.ALL.sites_no_chr.vcf.gz
+++ b/assets/verifyBamID/Omni25_genotypes_1525_samples_v2.b38.PASS.ALL.sites_no_chr.vcf.gz
@@ -1,3 +1,4 @@
-A gzipped VCF containing the SNPs used to calculate contamination for for build GRCh38 and is used by the verifybamid app.
+A gzipped VCF containing the SNPs used to calculate contamination for for build GRCh38 and is used by the verifybamid app. The linking CAPA to this file is GEN.BI.619. Provenance of this
+file is described in https://cuhbioinformatics.atlassian.net/wiki/spaces/P/pages/2540240912/Updating+Omni25+genotypes+file+for+b38
 This file is copied into 001 (001_Reference/app_assets/verifyBamID)
 and can be found with file-G7YKFZj4kj47GxgQ2bKGYV1g

--- a/assets/verifyBamID/Omni25_genotypes_1525_samples_v2.b38.PASS.ALL.sites_no_chr.vcf.gz
+++ b/assets/verifyBamID/Omni25_genotypes_1525_samples_v2.b38.PASS.ALL.sites_no_chr.vcf.gz
@@ -1,0 +1,3 @@
+A gzipped VCF containing the SNPs used to calculate contamination for for build GRCh38 and is used by the verifybamid app.
+This file is copied into 001 (001_Reference/app_assets/verifyBamID)
+and can be found at project-G9FKYPQ4kBX36YFX155g2v39:file-G7YKFZj4kj47GxgQ2bKGYV1g


### PR DESCRIPTION
- Added placeholder file for omni25 genotypes vcf for GRCh38 
- File is in a new subdirectory for verifyBamID

Provenance https://cuhbioinformatics.atlassian.net/wiki/spaces/P/pages/2540240912/Updating+Omni25+genotypes+file+for+b38

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_001_reference/153)
<!-- Reviewable:end -->
