### PR TITLE
220711 g2t

### DIFF
--- a/dynamic_files/nirvana_genes2transcripts/220609_g2t.tsv
+++ b/dynamic_files/nirvana_genes2transcripts/220609_g2t.tsv
@@ -54258,7 +54258,8 @@ HGNC:5347	NM_001039132.3	not_clinical_transcript	not_canonical
 HGNC:5347	NM_001544.5	not_clinical_transcript	not_canonical
 HGNC:5348	NM_003259.4	not_clinical_transcript	not_canonical
 HGNC:37245	NM_001103167.1	not_clinical_transcript	not_canonical
-HGNC:30546	NM_001397406.1	clinical_transcript	not_canonical
+HGNC:30546	NM_001397406.1	not_clinical_transcript	not_canonical
+HGNC:30546	NM_001031734.4	clinical_transcript	not_canonical
 HGNC:30296	NM_133452.3	not_clinical_transcript	not_canonical
 HGNC:30296	NM_001366174.1	not_clinical_transcript	not_canonical
 HGNC:5346	NM_002162.5	not_clinical_transcript	not_canonical

--- a/dynamic_files/nirvana_genes2transcripts/220609_g2t.tsv
+++ b/dynamic_files/nirvana_genes2transcripts/220609_g2t.tsv
@@ -24635,11 +24635,11 @@ HGNC:23082	NM_001346188.2	not_clinical_transcript	not_canonical
 HGNC:23082	NM_001346189.2	not_clinical_transcript	not_canonical
 HGNC:23082	NM_001346187.2	not_clinical_transcript	not_canonical
 HGNC:9208	NM_001382659.3	not_clinical_transcript	not_canonical
-HGNC:9208	NM_001382658.3	not_clinical_transcript	not_canonical
+HGNC:9208	NM_001382658.3	clinical_transcript	not_canonical
 HGNC:9208	NM_001367562.3	not_clinical_transcript	not_canonical
 HGNC:9208	NM_001382662.3	not_clinical_transcript	not_canonical
 HGNC:9208	NM_001382655.3	not_clinical_transcript	not_canonical
-HGNC:9208	NM_001395413.1	clinical_transcript	not_canonical
+HGNC:9208	NM_001395413.1	not_clinical_transcript	not_canonical
 HGNC:9208	NM_001382657.2	not_clinical_transcript	not_canonical
 HGNC:21697	NM_031925.3	not_clinical_transcript	not_canonical
 HGNC:21697	NM_001363462.2	not_clinical_transcript	not_canonical

--- a/dynamic_files/nirvana_genes2transcripts/g2t.log
+++ b/dynamic_files/nirvana_genes2transcripts/g2t.log
@@ -65,3 +65,12 @@ HGNC:20492  NM_001370595.2
 HGNC:23216  NM_001367624.2
 HGNC:29187  NM_001353345.2
 HGNC:30546  NM_001397406.1
+
+220711:
+Our GFF cache is not the same used in the VEP app. Meaning a few genes have no transcript:
+- PON
+- FDX2
+
+These need new transcripts to be assigned:
+- PON NM_001382658.3
+- FDX2 NM_001031734.4


### PR DESCRIPTION
Our GFF cache is not the same used in the VEP app. Meaning a few genes have no transcript:
- PON
- FDX2

These need new transcripts to be assigned:
- PON NM_001382658.3
- FDX2 NM_001031734.4

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_001_reference/159)
<!-- Reviewable:end -->
