### PR TITLE
added placeholder for gencode.v41.annotation.no_chr.gtf.gz

### DIFF
--- a/annotation/b38/gencode/gencode.v41.annotation.no_chr.gtf.gz
+++ b/annotation/b38/gencode/gencode.v41.annotation.no_chr.gtf.gz
@@ -1,0 +1,7 @@
+Documentation for removal of 'chr' prefix from chromosome numbers:
+https://cuhbioinformatics.atlassian.net/l/cp/32My46Be
+
+File was originally downloaded from here: https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_41/gencode.v41.annotation.gtf.gz
+and its provenance is documented here: https://cuhbioinformatics.atlassian.net/l/cp/BK4ehe4f
+
+File ID: file-GJ3F9B842QQq3j1g60PP0jBf


### PR DESCRIPTION
Add gencode.v41.annotation.no_chr.gtf.gz, which is a .gtf.gz file for genome annotation. This version is the same as the GENCODE Comprehensive gene annotation Release 41 (GRCh38.p13) (gencode.v41.annotation.gtf.gz) but it has the 'chr' prefix removed from the chromosome numbers.