### PR TITLE
VEP 103 RefSeq cache change

### DIFF
--- a/annotation/b38/vep/homo_sapiens_non_indexed_refseq_vep_103_GRCh38.tar.gz
+++ b/annotation/b38/vep/homo_sapiens_non_indexed_refseq_vep_103_GRCh38.tar.gz
@@ -1,0 +1,2 @@
+VEP RefSeq non-indexed cache, downloaded from: http://ftp.ensembl.org/pub/release-103/variation/vep/homo_sapiens_refseq_vep_103_GRCh38.tar.gz
+dx-file-id: file-G61yF38433GQgP504Px5PZ4G

--- a/annotation/b38/vep/homo_sapiens_refseq_vep_103_GRCh38.tar.gz
+++ b/annotation/b38/vep/homo_sapiens_refseq_vep_103_GRCh38.tar.gz
@@ -1,2 +1,2 @@
-VEP RefSeq reference, downloaded from: http://ftp.ensembl.org/pub/release-103/variation/vep/homo_sapiens_refseq_vep_103_GRCh38.tar.gz
-dx-file-id: file-G61yF38433GQgP504Px5PZ4G
+VEP RefSeq indexed cache, downloaded from: https://ftp.ensembl.org/pub/release-103/variation/indexed_vep_cache/homo_sapiens_refseq_vep_103_GRCh38.tar.gz
+dx-file-id: file-Gqpj9Pj4x0kG0QY2vY77VQ4J


### PR DESCRIPTION
- Rename placeholder for old 103 cache -> `homo_sapiens_non_indexed_refseq_vep_103_GRCh38.tar.gz`
- Add new file as placeholder for new indexed 103 cache `homo_sapiens_refseq_vep_103_GRCh38.tar.gz`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_001_Reference/261)
<!-- Reviewable:end -->
